### PR TITLE
Changes to support linking dokany 2 DLL

### DIFF
--- a/scripts/msvscpp-convert.py
+++ b/scripts/msvscpp-convert.py
@@ -44,6 +44,7 @@ def Main():
   """
   output_formats = frozenset([
       '2008', '2010', '2012', '2013', '2015', '2017', '2019', '2022'])
+  dokan_vers = frozenset([0, 1, 2])
 
   argument_parser = argparse.ArgumentParser(description=(
       'Converts source directory (autoconf and automake files) into '
@@ -79,7 +80,8 @@ def Main():
 
   argument_parser.add_argument(
       '--with_dokany', '--with-dokany', dest='with_dokany',
-      action='store_true', default=False, help='use DokanY instead of Dokan.')
+      choices=dokan_vers, type=int, default=0,
+      help='use DokanY instead of Dokan with DokanY version.')
 
   options = argument_parser.parse_args()
 

--- a/vstools/solutions.py
+++ b/vstools/solutions.py
@@ -13,7 +13,7 @@ class VSSolution(object):
 
   def __init__(
       self, extend_with_x64=True, generate_python_dll=True,
-      python_path='C:\\Python27', with_dokany=False):
+      python_path='C:\\Python27', with_dokany=0):
     """Initializes a Visual Studio solution.
 
     Args:
@@ -22,8 +22,8 @@ class VSSolution(object):
       generate_python_dll (Optional[bool]): True if a Python module DLL
           should be generated.
       python_path (Optional[str]): path to the Python installation.
-      with_dokany (Optional[bool]): True if DokanY should be used instead
-          of Dokan.
+      with_dokany (Optional[int]): 1 or higher if DokanY should be used 
+          instead of Dokan.
     """
     super(VSSolution, self).__init__()
     self._extend_with_x64 = extend_with_x64
@@ -97,9 +97,14 @@ class VSSolution(object):
               configuration = 'Debug'
 
             project_configuration.additional_dependencies.remove(library_path)
-            library_path = (
-                '..\\..\\..\\dokany\\dokan\\$(Platform)\\{0:s}\\'
-                'dokan1.lib').format(configuration)
+            if self._with_dokany == 2:
+              library_path = (
+                  '..\\..\\..\\dokany\\dokan\\$(Platform)\\'
+                  '$(ConfigurationName)\\dokan2.lib')
+            else:
+              library_path = (
+                  '..\\..\\..\\dokany\\dokan\\$(Platform)\\{0:s}\\'
+                  'dokan1.lib').format(configuration)
 
             project_configuration.additional_dependencies.append(library_path)
 


### PR DESCRIPTION
Recent dokany repository creates dokan2.lib instead of dokan1.lib. Therefore, even if I use the --with-dokany option, the compilation failed with the link error (LNK1181) like below.

The command I used.
```
powershell -exec bypass .\build.ps1 -PythonPath "$env:localappdata\Programs\Python\Python312" -VSToolsOptions "--extend-with-x64` --with-dokany` --python-path` $env:localappdata\Programs\Python\Python312" -Platform x64
```

The failed log related to linking dokan1.lib.
```
LINK : fatal error LNK1181: cannot open input file '..\..\..\dokany\dokan\x64\Release\dokan1.lib' [E:\devel\libyal\libewf_test\libewf\vs2022\ewfmount\ewfmount.vcxproj]
```

So I modified vstools to support dokany v2 by changing the variable type bool to int for the --with-dokany option.
If you want to use the latest dokany repository, which is taken by syncdokan.ps1, you can add the option with a version number like "--with-dokany 2".
```
powershell -exec bypass .\build.ps1 -PythonPath "$env:localappdata\Programs\Python\Python312" -VSToolsOptions "--extend-with-x64` --with-dokany` 2` --python-path` $env:localappdata\Programs\Python\Python312" -Platform x64
```
